### PR TITLE
Update badge URLs to use openbuildings/shipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Purchases Shipping
 
-[![Build Status](https://travis-ci.org/OpenBuildings/jam-shipping.png?branch=master)](https://travis-ci.org/OpenBuildings/jam-shipping)
-[![Coverage Status](https://coveralls.io/repos/OpenBuildings/jam-shipping/badge.png?branch=master)](https://coveralls.io/r/OpenBuildings/jam-shipping?branch=master)
-[![Latest Stable Version](https://poser.pugx.org/openbuildings/jam-shipping/v/stable.png)](https://packagist.org/packages/openbuildings/jam-shipping)
+[![Build Status](https://travis-ci.org/OpenBuildings/shipping.png?branch=master)](https://travis-ci.org/OpenBuildings/shipping)
+[![Coverage Status](https://coveralls.io/repos/OpenBuildings/shipping/badge.png?branch=master)](https://coveralls.io/r/OpenBuildings/shipping?branch=master)
+[![Latest Stable Version](https://poser.pugx.org/openbuildings/shipping/v/stable.png)](https://packagist.org/packages/openbuildings/shipping)
 
 ## Usage
 


### PR DESCRIPTION
I have fixed the badges URLs, but the package has still to be submitted to Packagist.
