### PR TITLE
Lock PHPUnit version to 4.1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,13 @@ before_script:
   - composer install
   - mysql -e 'create database `OpenBuildings/shipping`;'
   - mysql OpenBuildings/shipping < tests/test_data/structure.sql
+  - test -d $HOME/bin || mkdir $HOME/bin
+  - wget --output-document=$HOME/bin/phpunit https://phar.phpunit.de/phpunit-4.1.5.phar
+  - chmod +x $HOME/bin/phpunit
+  - export PATH=$HOME/bin:$PATH
 
 script:
-  - phpunit --coverage-clover build/logs/clover.xml
+  - $HOME/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
Newer versions of PHPUnit ouputs test in a different way and
this is contradicting with the session.

Ultimately we would nott need to touch the session in such tests at all.
