### PR TITLE
Fixed adding shipping items not marking the brand purchase shipping as changed

### DIFF
--- a/classes/Kohana/Model/Brand/Purchase/Shipping.php
+++ b/classes/Kohana/Model/Brand/Purchase/Shipping.php
@@ -215,6 +215,9 @@ class Kohana_Model_Brand_Purchase_Shipping extends Jam_Model implements Sellable
 	{
 		$this->items []= $this->new_item_from($purchase_item, $this->ship_to(), $method);
 
+		// Mark the shipping as changed so it can be properly saved
+		$this->items = $this->items;
+
 		return $this;
 	}
 

--- a/tests/tests/Model/Brand/Purchase/ShippingTest.php
+++ b/tests/tests/Model/Brand/Purchase/ShippingTest.php
@@ -212,6 +212,7 @@ class Model_Brand_Purchase_ShippingTest extends Testcase_Shipping {
 		$brand_purchase_shipping->build_item_from($purchase_item, $method);
 
 		$this->assertEquals($expected, $brand_purchase_shipping->items[0]);
+		$this->assertTrue($brand_purchase_shipping->changed('items'));
 	}
 
 	/**


### PR DESCRIPTION
Because of Jam's limitations when saving a model with associations multiple levels deep, when we add a new shipping item it isn't being saved when the brand_purchase is saved. 