### PR TITLE
Fixed shipping items not being updated when their shipping group is missing/deleted

### DIFF
--- a/classes/Kohana/Jam/Behavior/Shippable/Brand/Purchase.php
+++ b/classes/Kohana/Jam/Behavior/Shippable/Brand/Purchase.php
@@ -121,6 +121,8 @@ class Kohana_Jam_Behavior_Shippable_Brand_Purchase extends Jam_Behavior {
 				if ( ! $purchase_item->shipping_item)
 				{
 					$brand_purchase->shipping->build_item_from($purchase_item);
+				} else if ( ! $purchase_item->shipping_item->shipping_group) {
+					$purchase_item->shipping_item->update_address($brand_purchase->shipping);
 				}
 			}
 		}

--- a/tests/tests/Jam/Behavior/Shippable/Brand/PurchaseTest.php
+++ b/tests/tests/Jam/Behavior/Shippable/Brand/PurchaseTest.php
@@ -72,6 +72,11 @@ class Jam_Behavior_Shippable_Brand_PurchaseTest extends Testcase_Shipping {
 
 		$this->assertCount(1, $brand_purchase->shipping->items);
 		$this->assertSame($brand_purchase->items[0], $brand_purchase->shipping->items[0]->purchase_item);
+
+		$item = $brand_purchase->shipping->items[0];
+		$item->shipping_group = null;
+		$brand_purchase->update_items();
+		$this->assertNotNull($item->shipping_group);
 	}
 
 	/**


### PR DESCRIPTION
When the shipping group is deleted the existing shipping items are not being updated unless the purchase address changes.