### PR TITLE
Mark shipping item as updated

### DIFF
--- a/classes/Kohana/Jam/Behavior/Shippable/Brand/Purchase.php
+++ b/classes/Kohana/Jam/Behavior/Shippable/Brand/Purchase.php
@@ -123,6 +123,7 @@ class Kohana_Jam_Behavior_Shippable_Brand_Purchase extends Jam_Behavior {
 					$brand_purchase->shipping->build_item_from($purchase_item);
 				} else if ( ! $purchase_item->shipping_item->shipping_group) {
 					$purchase_item->shipping_item->update_address($brand_purchase->shipping);
+					$purchase_item->shipping_item = $purchase_item->shipping_item;
 				}
 			}
 		}


### PR DESCRIPTION
Updating the shipping item doesn't trigger save on shipping item from purchase item, `$purchase_item->shipping_item = $purchase_item->shipping_item;` explicitly mark changes in the purchase item. 