### PR TITLE
Update brand purchase shipping items

### DIFF
--- a/classes/Kohana/Jam/Behavior/Shippable/Brand/Purchase.php
+++ b/classes/Kohana/Jam/Behavior/Shippable/Brand/Purchase.php
@@ -116,6 +116,8 @@ class Kohana_Jam_Behavior_Shippable_Brand_Purchase extends Jam_Behavior {
 				$brand_purchase->shipping = $brand_purchase->shipping;
 			}
 
+			$shipping_items = array();
+
 			foreach ($brand_purchase->items(array('shippable' => TRUE)) as $purchase_item)
 			{
 				if ( ! $purchase_item->shipping_item)
@@ -125,7 +127,11 @@ class Kohana_Jam_Behavior_Shippable_Brand_Purchase extends Jam_Behavior {
 					$purchase_item->shipping_item->update_address($brand_purchase->shipping);
 					$purchase_item->shipping_item = $purchase_item->shipping_item;
 				}
+
+				$shipping_items [] = $purchase_item->shipping_item;
 			}
+
+			$brand_purchase->shipping->items = $shipping_items;
 		}
 	}
 

--- a/tests/tests/Model/Brand/Purchase/ShippingTest.php
+++ b/tests/tests/Model/Brand/Purchase/ShippingTest.php
@@ -545,6 +545,6 @@ class Model_Brand_Purchase_ShippingTest extends Testcase_Shipping {
 		$result = Jam::find('purchase', 2);
 
 		$this->assertEquals($result->brand_purchases[0]->items[3]->reference->id(), $purchase->brand_purchases[0]->shipping->id());
-		$this->assertEquals($result->brand_purchases[0]->items[2]->id(), $purchase->brand_purchases[0]->shipping->items[1]->purchase_item->id());
+		$this->assertEquals($result->brand_purchases[0]->items[2]->id(), $purchase->brand_purchases[0]->shipping->items[2]->purchase_item->id());
 	}
 }


### PR DESCRIPTION
Updating `brand_purchase_shipping` association with updated shipping items.

`update_items` updates the shipping items, `freeze` method reads the shipping items from `Model_Brand_Purchase_Shipping` and the aim of this PR is to sync the items in `Model_Brand_Purchase_Shipping` on `update_items` call.