### PR TITLE
Allow zero price for shipping group

### DIFF
--- a/classes/Kohana/Model/Shipping/Group.php
+++ b/classes/Kohana/Model/Shipping/Group.php
@@ -30,7 +30,8 @@ class Kohana_Model_Shipping_Group extends Jam_Model {
 				'additional_item_price' => Jam::field('price', array('convert_empty' => FALSE)),
 				'discount_threshold' => Jam::field('price'),
 			))
-			->validator('price', 'shipping', 'location', 'method', 'delivery_time', array('present' => TRUE))
+			->validator('shipping', 'location', 'method', 'delivery_time', array('present' => TRUE))
+			->validator('price', array('present' => array('allow_zero' => TRUE)))
 			->validator('additional_item_price', 'discount_threshold', 'price', array('price' => array('greater_than_or_equal_to' => 0)))
 			->validator('delivery_time', array('range' => array('consecutive' => TRUE, 'greater_than_or_equal_to' => 0)));
 	}


### PR DESCRIPTION
Whit changes in openbuildings/jam:0.5.22 and openbuildings/jam-monetory:0.1.24 we have to change price validation to allow zero